### PR TITLE
[fix] Monotonic nano timestamp

### DIFF
--- a/include/qb/core/VirtualCore.h
+++ b/include/qb/core/VirtualCore.h
@@ -33,6 +33,7 @@
 #endif
 
 // include from qb
+# include <qb/system/timestamp.h>
 # include <qb/system/allocator/pipe.h>
 # include <qb/system/lockfree/mpsc.h>
 # include "ICallback.h"

--- a/include/qb/system/timestamp.h
+++ b/include/qb/system/timestamp.h
@@ -285,36 +285,6 @@ namespace qb {
 
 
         static uint64_t epoch() noexcept { return 0; }
-        static uint64_t utc()  {
-			// Get current system time
-			//std::time_t system_now = std::time(0);
-
-			// Convert to UTC
-			//tm utc_now;
-			//gmtime_s(&utc_now, &system_now);
-			//time_t utc_time = mktime(&utc_now);
-
-			// Compute difference between system time and utc in nanoseconds
-			//uint64_t diff = std::abs(utc_time - system_now) * 1000000000;
-			//bool diff_sign = ((utc_time - system_now) < 0);
-			//return ((diff_sign) ? (nano() - diff) : (nano() + diff));
-            return nano();
-        }
-        static uint64_t local() {
-			// Get current system time
-			//std::time_t system_now = std::time(0);
-
-			// Convert to local time
-			//tm local_now;
-			//localtime_s(&local_now, &system_now);
-			//time_t local_time = mktime(&local_now);
-
-			// Compute difference between system time and local time in nanoseconds
-			//uint64_t diff = std::abs(local_time - system_now) * 1000000000;
-			//bool diff_sign = ((local_time - system_now) < 0);
-			//return ((diff_sign) ? (nano() - diff) : (nano() + diff));
-            return nano();
-        }
         static uint64_t nano() {
 			// Store system time and steady time on first call
 			static std::chrono::time_point<std::chrono::system_clock> clk_system_start = std::chrono::system_clock::now();

--- a/include/qb/system/timestamp.h
+++ b/include/qb/system/timestamp.h
@@ -287,31 +287,33 @@ namespace qb {
         static uint64_t epoch() noexcept { return 0; }
         static uint64_t utc()  {
 			// Get current system time
-			std::time_t system_now = std::time(0);
+			//std::time_t system_now = std::time(0);
 
 			// Convert to UTC
-			tm utc_now;
-			gmtime_s(&utc_now, &system_now);
-			time_t utc_time = mktime(&utc_now);
+			//tm utc_now;
+			//gmtime_s(&utc_now, &system_now);
+			//time_t utc_time = mktime(&utc_now);
 
 			// Compute difference between system time and utc in nanoseconds
-			uint64_t diff = std::abs(utc_time - system_now) * 1000000000;
-			bool diff_sign = ((utc_time - system_now) < 0);
-			return ((diff_sign) ? (nano() - diff) : (nano() + diff));
+			//uint64_t diff = std::abs(utc_time - system_now) * 1000000000;
+			//bool diff_sign = ((utc_time - system_now) < 0);
+			//return ((diff_sign) ? (nano() - diff) : (nano() + diff));
+            return nano();
         }
         static uint64_t local() {
 			// Get current system time
-			std::time_t system_now = std::time(0);
+			//std::time_t system_now = std::time(0);
 
 			// Convert to local time
-			tm local_now;
-			localtime_s(&local_now, &system_now);
-			time_t local_time = mktime(&local_now);
+			//tm local_now;
+			//localtime_s(&local_now, &system_now);
+			//time_t local_time = mktime(&local_now);
 
 			// Compute difference between system time and local time in nanoseconds
-			uint64_t diff = std::abs(local_time - system_now) * 1000000000;
-			bool diff_sign = ((local_time - system_now) < 0);
-			return ((diff_sign) ? (nano() - diff) : (nano() + diff));
+			//uint64_t diff = std::abs(local_time - system_now) * 1000000000;
+			//bool diff_sign = ((local_time - system_now) < 0);
+			//return ((diff_sign) ? (nano() - diff) : (nano() + diff));
+            return nano();
         }
         static uint64_t nano() {
 			// Store system time and steady time on first call

--- a/include/qb/system/timestamp.h
+++ b/include/qb/system/timestamp.h
@@ -319,7 +319,7 @@ namespace qb {
     public:
         using Timestamp::Timestamp;
 
-        UtcTimestamp() : Timestamp(Timestamp::utc()) {}
+        UtcTimestamp() : Timestamp(Timestamp::nano()) {}
         UtcTimestamp(const Timestamp& timestamp) : Timestamp(timestamp) {}
     };
 
@@ -328,7 +328,7 @@ namespace qb {
     public:
         using Timestamp::Timestamp;
 
-        LocalTimestamp() : Timestamp(Timestamp::local()) {}
+        LocalTimestamp() : Timestamp(Timestamp::nano()) {}
         LocalTimestamp(const Timestamp& timestamp) : Timestamp(timestamp) {}
     };
 

--- a/modules/nanolog/nanolog.cpp
+++ b/modules/nanolog/nanolog.cpp
@@ -33,6 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 #include <queue>
 #include <fstream>
 #include <qb/utility/build_macros.h>
+#include <qb/system/timestamp.h>
 #include "nanolog.h"
 
 namespace
@@ -41,7 +42,7 @@ namespace
 	/* Returns microseconds since epoch */
 	uint64_t timestamp_now()
 	{
-		return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+		return qb::Timestamp::nano() / 1000;
 	}
 
 	/* I want [2016-10-13 00:01:23.528514] */

--- a/source/core/tests/shared/TestEvent.h
+++ b/source/core/tests/shared/TestEvent.h
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <chrono>
 #include <qb/event.h>
+#include <qb/system/timestamp.h>
 
 #ifndef QB_TESTEVENT_H
 #define QB_TESTEVENT_H


### PR DESCRIPTION
Added a monotonic clock based nano timestamp. which doesn't take operating system time change at runtime into account.